### PR TITLE
Make URL command line argument(s) optional. Change check for len(sys.argv) < 3 to len(sys.argv) < 2

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -5,7 +5,7 @@
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
 """
-USAGE: %(program)s OUTPUT_DIRECTORY URL1 [URL2 ...]
+USAGE: %(program)s OUTPUT_DIRECTORY [URL1, URL2 ...]
 
 Download all files pointed at by the given URLs, into OUTPUT_DIRECTORY (which must already exist).
 
@@ -50,7 +50,7 @@ if __name__ == '__main__':
 
     # check and process cmdline input
     program = os.path.basename(sys.argv[0])
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 2:
         print(globals()['__doc__'] % locals())
         sys.exit(1)
     outdir = sys.argv[1]


### PR DESCRIPTION
Running the program with:

```
python download_data.py ./data
```

did not work as expected, since len(sys.argv) < 3 in this case (the value of len(sys.argv) is 2).
